### PR TITLE
tmux: copy-mode の半ページスクロールと prefix+v での起動を追加

### DIFF
--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -18,10 +18,13 @@ set -g set-titles on
 set -g set-titles-string "#T"
 
 # Copy mode
+bind v copy-mode
 bind -T copy-mode-vi v send -X begin-selection
 bind -T copy-mode-vi y send -X copy-pipe-and-cancel "pbcopy"
 bind -T copy-mode-vi Enter send -X copy-pipe-and-cancel "pbcopy"
 bind -T copy-mode-vi MouseDragEnd1Pane send -X copy-pipe-and-cancel "pbcopy"
+bind -T copy-mode-vi d send -X halfpage-down
+bind -T copy-mode-vi u send -X halfpage-up
 
 # Utility
 bind r source-file ~/.config/tmux/tmux.conf \; display "Reloaded!"


### PR DESCRIPTION
## Summary
- copy-mode-vi で `d` / `u` を halfpage-down / halfpage-up に bind
- `prefix + v` で copy-mode に入れるよう bind（`v` はデフォルト・既存設定で未使用のため衝突なし）

## Test plan
- [ ] `prefix + r` で設定リロード後、`prefix + v` で copy-mode に入れる
- [ ] copy-mode 中に `d` / `u` で半ページスクロールできる
- [ ] 既存の `v`（選択開始）/ `y`（pbcopy）が引き続き動く

🤖 Generated with [Claude Code](https://claude.com/claude-code)