### PR TITLE
claude: defaultMode を auto に変更し skipAutoPermissionPrompt を有効化

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -56,7 +56,7 @@
       "Bash(pip upload:*)",
       "Bash(twine upload:*)"
     ],
-    "defaultMode": "default"
+    "defaultMode": "auto"
   },
   "hooks": {
     "Stop": [
@@ -87,5 +87,6 @@
   "enabledPlugins": {
     "typescript-lsp@claude-plugins-official": true,
     "lua-lsp@claude-plugins-official": true
-  }
+  },
+  "skipAutoPermissionPrompt": true
 }


### PR DESCRIPTION
## Summary
- `defaultMode` を `default` → `auto` に変更（Claude Code を自動モード起動に）
- `skipAutoPermissionPrompt: true` を追加し、自動モード突入時の確認プロンプトをスキップ

## Test plan
- [ ] Claude Code を起動して自動モードで開始されることを確認
- [ ] 自動モード時の冒頭の権限確認プロンプトが出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)