### PR TITLE
tmux-agent-sidebar を導入

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -117,7 +117,16 @@
   },
   "enabledPlugins": {
     "typescript-lsp@claude-plugins-official": true,
-    "lua-lsp@claude-plugins-official": true
+    "lua-lsp@claude-plugins-official": true,
+    "tmux-agent-sidebar@hiroppy": true
+  },
+  "extraKnownMarketplaces": {
+    "hiroppy": {
+      "source": {
+        "source": "directory",
+        "path": "/Users/yuki/.tmux/plugins/tmux-agent-sidebar"
+      }
+    }
   },
   "skipAutoPermissionPrompt": true
 }

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -33,7 +33,7 @@ bind -T copy-mode-vi u send -X halfpage-up
 # Utility
 bind r source-file ~/.config/tmux/tmux.conf \; display "Reloaded!"
 bind o run-shell "open '#{pane_current_path}'"
-bind e kill-pane -a
+bind X kill-pane -a
 bind g display-popup -d '#{pane_current_path}' -w80% -h80% -E lazygit
 bind -r y run-shell '\
   SESSION="claude-$(echo #{pane_current_path} | md5 | cut -c1-8)"; \
@@ -66,3 +66,8 @@ set-option -g display-panes-colour colour166
 set-window-option -g clock-mode-colour colour64
 
 source ~/.config/tmux/statusline.conf
+
+# tmux-agent-sidebar (手動インストール: ~/.tmux/plugins/tmux-agent-sidebar)
+# 新規 window での自動 spawn は無効。prefix + e / prefix + E で手動トグル。
+set -g @sidebar_auto_create off
+run-shell '~/.tmux/plugins/tmux-agent-sidebar/tmux-agent-sidebar.tmux'


### PR DESCRIPTION
## Summary

- 全 session/window 横断で AI agent pane を一覧する tmux サイドバー [hiroppy/tmux-agent-sidebar](https://github.com/hiroppy/tmux-agent-sidebar) を導入
- TPM は使わず、`~/.tmux/plugins/tmux-agent-sidebar` への手動 `git clone` + `run-shell` で読み込む方針（fisher は使うが TPM はナシ、という現状の管理思想に合わせた）
- `prefix + e` をサイドバーに譲るため、`kill-pane -a` を `prefix + X` に退避
- 新規 window で自動 spawn される挙動は無効化（`@sidebar_auto_create off`）。必要な window でだけ `prefix + e` で手動トグル
- Claude Code 側は `/plugin install tmux-agent-sidebar@hiroppy` で hook を有効化済み（`settings.json` の `enabledPlugins` / `extraKnownMarketplaces` 追加はその副作用）

## 既存実装との関係

既存の `@claude_waiting` ステータスバー赤囲い (`tmux/statusline.conf`) + 通知音 (`claude/settings.json` の Stop / PermissionRequest hook) は **併用継続**。サイドバーとは役割が違うので機能が重ならない:

| 既存実装 | サイドバー |
|---|---|
| ステータスバーの赤背景【 】で応答待ち window を強調 | サイドバー行の `◐` アイコンで状態表示 |
| `Glass.aiff` / `Funk.aiff` で完了/許可待ちを鳴らし分け | デスクトップ通知 |
| popup Claude → 親 window への伝搬 | 全 session 横断の行表示 |

## Test plan

- [ ] `tmux source ~/.config/tmux/tmux.conf` でエラーなくロードできる
- [ ] `prefix + e` でサイドバーがトグル開閉する
- [ ] `prefix + X` で `kill-pane -a` が動く
- [ ] Claude Code 起動中の window がサイドバー行に出る
- [ ] Claude が応答完了したとき、既存の通知音 + ステータスバー赤囲い + サイドバー `◐` の三重で気づける
- [ ] popup Claude (`bind y`) もサイドバー行に出る

🤖 Generated with [Claude Code](https://claude.com/claude-code)