### PR TITLE
tmux-agent-sidebar を常時表示にし配色を gruber に寄せる

### DIFF
--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -68,6 +68,14 @@ set-window-option -g clock-mode-colour colour64
 source ~/.config/tmux/statusline.conf
 
 # tmux-agent-sidebar (手動インストール: ~/.tmux/plugins/tmux-agent-sidebar)
-# 新規 window での自動 spawn は無効。prefix + e / prefix + E で手動トグル。
-set -g @sidebar_auto_create off
+# 新規 window で自動的にサイドバー pane を spawn する（常時表示モード）
+set -g @sidebar_auto_create on
+
+# 配色を gruber/alacritty パレットに寄せる
+set -g @sidebar_color_accent 146           # ラベンダー (#9E95C7 ≈ #AFAFD7)
+set -g @sidebar_color_session 146          # session 名も accent と統一
+set -g @sidebar_color_waiting 220          # gruber 黄 (#FFDD33 ≈ #FFD700)
+set -g @sidebar_color_error 196            # gruber 赤 (#F43841 ≈ #FF0000)
+set -g @sidebar_color_text_active 254      # foreground (#E4E4E4 完全一致)
+
 run-shell '~/.tmux/plugins/tmux-agent-sidebar/tmux-agent-sidebar.tmux'


### PR DESCRIPTION
## Summary

- `@sidebar_auto_create` を `off` → `on` にし、新規 window で自動的にサイドバー pane が spawn されるよう変更（手動トグル運用 → 常時表示運用）
- 配色を既存の `statusline.conf` / alacritty パレットに寄せる:
  - `accent` / `session`: ラベンダー `#9E95C7` ≈ xterm `146`
  - `waiting`: gruber 黄 `#FFDD33` ≈ xterm `220`
  - `error`: gruber 赤 `#F43841` ≈ xterm `196`
  - `text_active`: foreground `#E4E4E4` = xterm `254`（完全一致）
- `running` (緑) と `idle` (青) は状態の見分けやすさを優先してデフォルト維持

## Test plan

- [ ] `prefix + r` で reload 後、新 window 作成時にサイドバー pane が自動で出る
- [ ] サイドバー上の session 名がラベンダーで表示される（既存ステータスバー左端と同系色）
- [ ] 応答待ち (`◐`) の黄色が tmux ステータスバーのカレント window 黄と揃って見える
- [ ] エラー (`✕`) の赤が `@claude_waiting` 赤背景と同系で表示される
- [ ] 通常時のテキストが foreground gray (`#E4E4E4`) と一致する

🤖 Generated with [Claude Code](https://claude.com/claude-code)