### PR TITLE
tmux-agent-sidebar の幅を 20% に広げる

### DIFF
--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -70,6 +70,7 @@ source ~/.config/tmux/statusline.conf
 # tmux-agent-sidebar (手動インストール: ~/.tmux/plugins/tmux-agent-sidebar)
 # 新規 window で自動的にサイドバー pane を spawn する（常時表示モード）
 set -g @sidebar_auto_create on
+set -g @sidebar_width 20%
 
 # 配色を gruber/alacritty パレットに寄せる
 set -g @sidebar_color_accent 146           # ラベンダー (#9E95C7 ≈ #AFAFD7)


### PR DESCRIPTION
## Summary

- `@sidebar_width` をデフォルト `15%` から `20%` に変更
- 常時表示モード (`@sidebar_auto_create on`) で運用するようになり、デフォルト幅では文字が窮屈になっていたため少し広げる

## Test plan

- [ ] `prefix + r` で reload 後、サイドバー pane が画面幅の 20% を占める
- [ ] エージェント行のセッション名 / ブランチ / プロンプトプレビューが折り返さずに読める
- [ ] メイン作業エリアが過度に圧迫されない（13" MacBook 内蔵ディスプレイで確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)