### PR TITLE
claude: claude-obsidian プラグインを有効化

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -118,13 +118,20 @@
   "enabledPlugins": {
     "typescript-lsp@claude-plugins-official": true,
     "lua-lsp@claude-plugins-official": true,
-    "tmux-agent-sidebar@hiroppy": true
+    "tmux-agent-sidebar@hiroppy": true,
+    "claude-obsidian@claude-obsidian-marketplace": true
   },
   "extraKnownMarketplaces": {
     "hiroppy": {
       "source": {
         "source": "directory",
         "path": "/Users/yuki/.tmux/plugins/tmux-agent-sidebar"
+      }
+    },
+    "claude-obsidian-marketplace": {
+      "source": {
+        "source": "github",
+        "repo": "AgriciDaniel/claude-obsidian"
       }
     }
   },


### PR DESCRIPTION
## Summary
- AgriciDaniel/claude-obsidian マーケットプレイスを extraKnownMarketplaces に追加
- claude-obsidian プラグインを enabledPlugins で有効化

## Test plan
- [ ] Claude Code 起動時に claude-obsidian 由来のスキル(/wiki, /save, /autoresearch など)が読み込まれる

🤖 Generated with [Claude Code](https://claude.com/claude-code)