### PR TITLE
fix(claude): AskUserQuestion 直後の Stop で tmux waiting フラグが再点灯する問題を解消

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -65,7 +65,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "afplay /System/Library/Sounds/Glass.aiff & osascript -e 'display notification \"応答が完了しました\" with title \"Claude Code\"' 2>/dev/null; ~/.claude/tmux-waiting.sh set 2>/dev/null; true"
+            "command": "afplay /System/Library/Sounds/Glass.aiff & osascript -e 'display notification \"応答が完了しました\" with title \"Claude Code\"' 2>/dev/null; ~/.claude/tmux-waiting.sh set-unless-suppressed 2>/dev/null; true"
           }
         ]
       }
@@ -96,7 +96,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "~/.claude/tmux-waiting.sh clear 2>/dev/null; true"
+            "command": "~/.claude/tmux-waiting.sh clear 2>/dev/null; ~/.claude/tmux-waiting.sh suppress 2>/dev/null; true"
           }
         ]
       }

--- a/claude/tmux-waiting.sh
+++ b/claude/tmux-waiting.sh
@@ -2,14 +2,40 @@
 # Toggle the @claude_waiting tmux user option on the current pane's window,
 # and propagate to the parent pane recorded in CLAUDE_PARENT_PANE
 # (set by `bind y` in tmux.conf when launching the popup).
-# Usage: tmux-waiting.sh set|clear
+#
+# Usage: tmux-waiting.sh set|set-unless-suppressed|clear|suppress
+#
+#   set                   -- unconditionally set the waiting flag
+#                            (used by PermissionRequest hook)
+#   set-unless-suppressed -- set the flag unless a suppress sentinel exists;
+#                            consumes the sentinel either way
+#                            (used by Stop hook so the Stop fired right after
+#                             the user answers AskUserQuestion does not re-red
+#                             the tab)
+#   clear                 -- unset the flag
+#   suppress              -- create a sentinel so the next
+#                            set-unless-suppressed call no-ops
+#                            (used by PostToolUse:AskUserQuestion)
 
 [ -n "$TMUX_PANE" ] || exit 0
 
+sentinel="/tmp/claude_skip_next_stop_$(printf '%s' "$TMUX_PANE" | tr -c 'a-zA-Z0-9' '_')"
+
 case "${1:-}" in
-  set)   set -- set-option -w -t "$TMUX_PANE" @claude_waiting 1 ;;
-  clear) set -- set-option -w -u -t "$TMUX_PANE" @claude_waiting ;;
-  *)     exit 1 ;;
+  set)
+    set -- set-option -w -t "$TMUX_PANE" @claude_waiting 1 ;;
+  set-unless-suppressed)
+    if [ -f "$sentinel" ]; then
+      rm -f "$sentinel"
+      exit 0
+    fi
+    set -- set-option -w -t "$TMUX_PANE" @claude_waiting 1 ;;
+  clear)
+    set -- set-option -w -u -t "$TMUX_PANE" @claude_waiting ;;
+  suppress)
+    : > "$sentinel"
+    exit 0 ;;
+  *) exit 1 ;;
 esac
 saved=("$@")
 


### PR DESCRIPTION
## Summary

- AskUserQuestion 回答直後に発火する Stop hook で tmux の `@claude_waiting` フラグが再点灯し、tab が red のままになる問題を修正
- `PostToolUse:AskUserQuestion` で sentinel ファイルを作成し、続く Stop hook の `set-unless-suppressed` がそれを消費して set をスキップする
- AskUserQuestion で `PreToolUse → PermissionRequest → PostToolUse → Stop` の順に hook が発火することを診断ログで確認済み (PR ではログ追加分は剥がし済み)

## Test plan

- [x] 同一セッションで AskUserQuestion を発火 → 回答 → 応答完了後に tab が red にならないことを確認
- [x] sentinel が Stop hook で consume (削除) されることを確認
- [x] settings.json が valid JSON であることを確認