### PR TITLE
fix(claude): permission 応答後の tmux waiting フラグを解除する

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -92,11 +92,20 @@
     ],
     "PostToolUse": [
       {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/tmux-waiting.sh clear 2>/dev/null; true"
+          }
+        ]
+      },
+      {
         "matcher": "AskUserQuestion",
         "hooks": [
           {
             "type": "command",
-            "command": "~/.claude/tmux-waiting.sh clear 2>/dev/null; ~/.claude/tmux-waiting.sh suppress 2>/dev/null; true"
+            "command": "~/.claude/tmux-waiting.sh suppress 2>/dev/null; true"
           }
         ]
       }

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -80,6 +80,16 @@
         ]
       }
     ],
+    "PermissionDenied": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/tmux-waiting.sh clear 2>/dev/null; true"
+          }
+        ]
+      }
+    ],
     "UserPromptSubmit": [
       {
         "hooks": [

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -92,7 +92,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": ".*",
+        "matcher": "*",
         "hooks": [
           {
             "type": "command",


### PR DESCRIPTION
## Summary
- Bash 等のツール permission yes/no を押下した後、`tmux-waiting.sh clear` を呼ぶフックが無く、赤い背景 (`@claude_waiting`) が解除されない問題を修正
- 既存の `PostToolUse` は matcher が `AskUserQuestion` 限定で、permission を伴う Bash/Edit/Write 等のフローでは `clear` が動かない
- そのまま `Stop` まで進むと `set-unless-suppressed` が再点灯させるため、ユーザは次の `UserPromptSubmit` か window 切替まで赤を見続けることになる

## 修正内容
`PostToolUse` を 2 つの entry に分割:

1. **全 tool 共通** (`matcher: ".*"`) → `tmux-waiting.sh clear`
2. **AskUserQuestion 限定** → `tmux-waiting.sh suppress` (Stop の `set-unless-suppressed` を抑制する既存挙動を維持)

これにより:
- AskUserQuestion: `clear` + `suppress` → Stop で再点灯しない (既存挙動)
- Bash etc. permission grant: `clear` のみ → Stop で再点灯 (Claude が次入力待ちなので正常)
- 自動許可された tool: `clear` (no-op、フラグはもともと立っていない)

## Test plan
- [ ] permission 必要な Bash を実行 → 赤背景になる → yes 押下 → 赤が消える
- [ ] AskUserQuestion → 選択 → 赤が消える、Stop でも再点灯しない (既存挙動が維持されている)
- [ ] 通常の Stop → 赤になる
- [ ] permission 必要な Bash を no で deny → 赤が残るかは未確認 (PostToolUse が deny 時に発火するか不明、本 PR では accept のみ対象)

🤖 Generated with [Claude Code](https://claude.com/claude-code)