### PR TITLE
feat(claude): t-wada style TDD skill を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,8 +27,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `claude/settings.json` → `~/.claude/settings.json`（ファイル単位リンク）
 - `claude/statusline.sh` → `~/.claude/statusline.sh`（ファイル単位リンク）
 - `claude/tmux-waiting.sh` → `~/.claude/tmux-waiting.sh`（ファイル単位リンク）
+- `claude/skills/<name>/` → `~/.claude/skills/<name>/`（skill ごとにディレクトリ単位リンク）
 
 `~/.claude/` 配下には `projects/`（会話履歴・auto-memory）、`sessions/`、`history.jsonl` など動的・機密ファイルが混在するため、ディレクトリ単位ではなく **ユーザーが手書きするファイルだけを個別リンク** する方針。
+
+例外として `claude/skills/<name>/` は skill 1 つが `SKILL.md` + `references/` 等の複数ファイルで完結する自己完結ユニットなので、skill ディレクトリ単位でリンクする。`~/.claude/skills/` 自体は静的内容しか入らないため安全。
 
 ## Neovim 設定のアーキテクチャ
 

--- a/claude/skills/tdd/SKILL.md
+++ b/claude/skills/tdd/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: tdd
+description: Guides t-wada Red-Green-Refactor TDD. Use when implementing features, fixing bugs, or refactoring logic with strict test-first development.
+---
+
+<!--
+Example prompts:
+  /tdd
+  /tdd implement user authentication
+  /tdd fix the cart total calculation bug
+-->
+
+You are following strict t-wada style Test-Driven Development. All code changes that involve logic (bug fixes, new features, refactors) **must** follow Red-Green-Refactor. No exceptions.
+
+**Project test environment:**
+
+```bash
+!`cat package.json 2>/dev/null | jq -r '.scripts | to_entries[] | select(.key | test("test")) | "\(.key): \(.value)"' 2>/dev/null || echo "No package.json test scripts found"`
+```
+
+```bash
+!`if [ -f vitest.config.ts ] || [ -f vitest.config.js ] || [ -f vitest.config.mts ]; then echo "Test runner: Vitest"; elif [ -f jest.config.ts ] || [ -f jest.config.js ] || [ -f jest.config.cjs ]; then echo "Test runner: Jest"; elif [ -f pytest.ini ] || { [ -f pyproject.toml ] && grep -q pytest pyproject.toml 2>/dev/null; }; then echo "Test runner: pytest"; elif [ -f Cargo.toml ]; then echo "Test runner: cargo test"; elif [ -f go.mod ]; then echo "Test runner: go test"; else echo "Test runner: unknown — ask the user"; fi`
+```
+
+## The Cycle
+
+1. **Red** — Write a failing test first. Run it and confirm it fails for the expected reason. Do **not** write any production code yet.
+2. **Green** — Write the **minimum** production code to make the failing test pass. Nothing more.
+3. **Refactor** — Clean up both test and production code while keeping all tests green. Remove duplication, improve naming, simplify structure.
+
+Repeat until the feature or fix is complete.
+
+## Rules
+
+- **Never write production code without a failing test that demands it.** If there is no red test, there is no reason to write code.
+- **One behavior per test.** Each test should verify exactly one thing. Name it after the behavior, not the implementation (e.g. `it("returns 0 for an empty cart")` not `it("test calculateTotal")`).
+- **Keep the green step as small as possible.** Fake it, then make it real. Triangulate with additional tests when needed.
+- **Run the affected test suite after every green and every refactor step.** Prefer running only changed/affected tests during the cycle for speed. Never skip this.
+- **Refactor only on green.** If a test is red, fix the production code first — do not restructure anything while tests are failing.
+- **Tests are first-class code.** Apply the same quality standards (naming, readability, no duplication) to test code as to production code.
+- **Do not satisfy TDD with content-existence tests.** A test like `expect(skillMd).toContain("some guidance")` is an anti-pattern unless it proves an executable contract rather than freezing wording.
+- **Do not delete or weaken a test to make the build pass.** If a test is wrong, fix the test with a clear reason — do not silently remove it.
+- **Bug fixes start with a regression test.** Before touching the bug, write a test that reproduces it and fails. Then fix the bug and confirm the test goes green.
+
+## Workflow
+
+1. **Sketch behaviors** — Before writing any code, list the behaviors to implement as placeholder tests (e.g. `it.todo(...)` in JS, `@pytest.mark.skip` in Python, `#[ignore]` in Rust).
+2. **Pick one behavior** — Start with the simplest or most fundamental one.
+3. **Red** — Write the test. Run it. Confirm it fails for the right reason.
+4. **Green** — Write the minimum code to pass. Run the test. Confirm it passes.
+5. **Refactor** — Clean up. Run all affected tests. Confirm everything is green.
+6. **Repeat** from step 2 until all behaviors are covered.
+
+## Test Execution
+
+Prefer running only the tests affected by your changes during the Red-Green-Refactor cycle. Full suite runs are for CI or final verification.
+
+**Runner-specific guidance** — Read the relevant example file alongside this skill for detailed test modifiers, idioms, and runner-specific tips:
+
+- **Vitest**: See `references/vitest-examples.md` — test modifiers (`it.todo`, `it.skip`, `it.fails`, etc.), `--changed` flag
+- **Rust (cargo test)**: Use focused runs like `cargo test <name>` and `cargo test -- --ignored`
+- **Zig (zig test)**: Use `zig test <file> --test-filter <name>` for focused runs
+
+For other runners, adapt the general patterns:
+
+- **Jest**: `pnpm jest --changedSince=HEAD` or `pnpm jest <test-file>`
+- **pytest**: `pytest <test-file>` or `pytest -x --lf`
+- **go**: `go test ./path/to/package`
+
+## Key Principles
+
+- When in doubt, write a smaller test
+- Each test should read like a specification of behavior
+- The test name is documentation — make it descriptive
+- If you cannot name a test clearly, the behavior is not well understood yet
+- Prefer testing public interfaces over internal implementation details
+- DO NOT DRY tests - duplication in tests are ok if it improves readability and clarity of intent. Refactor only when there is a clear benefit.

--- a/claude/skills/tdd/references/vitest-examples.md
+++ b/claude/skills/tdd/references/vitest-examples.md
@@ -1,0 +1,187 @@
+# Vitest TDD Reference
+
+## Running Tests
+
+```bash
+# Run only tests affected by uncommitted changes (preferred during TDD cycle)
+pnpm vitest --changed
+
+# Run a specific test file
+pnpm vitest src/utils/cart.test.ts
+
+# Run tests matching a name pattern
+pnpm vitest -t "returns 0 for an empty cart"
+```
+
+## Test Modifiers
+
+Vitest globals are enabled in this repository. Use `describe`, `test`, `it`, `expect`, `vi`, `beforeEach`, and `assert` directly without importing them from `vitest`.
+
+Use built-in modifiers instead of commenting out or deleting tests:
+
+- `it.todo("description")` — Placeholder for a test you plan to write. Use this to sketch out behaviors before implementing.
+- `it.skip("description", ...)` — Temporarily disable a test (e.g. blocked by an external dependency). Always leave a comment explaining why.
+- `it.fails("description", ...)` — Assert that a test **is expected to fail**. Useful during the Red phase to document a known bug while keeping the suite green.
+- `it.only("description", ...)` — Run only this test in the suite. Useful for focusing during the Red-Green cycle. **Remove before committing.**
+- `it.concurrent("description", ...)` — Run concurrently with other concurrent tests. Use when tests are independent.
+- `it.sequential("description", ...)` — Force sequential execution inside a concurrent suite. Use when a test depends on shared state.
+- `test.extend({...})` — Create a custom test function with fixtures for sharing setup logic.
+
+Modifiers can be chained (e.g. `it.skip.concurrent(...)`, `it.fails.only(...)`).
+
+See https://vitest.dev/api/test for the full API.
+
+## TDD Example
+
+```typescript
+import { calculateTotal } from './cart';
+
+describe('calculateTotal', () => {
+	// Step 1: Sketch behaviors with todo
+	it.todo('applies percentage discount');
+	it.todo('applies fixed amount discount');
+	it.todo('never returns a negative total');
+
+	// Step 2: Implement one at a time (Red → Green → Refactor)
+	it('returns 0 for an empty cart', () => {
+		expect(calculateTotal([])).toBe(0);
+	});
+
+	it('sums item prices', () => {
+		const items = [{ price: 10 }, { price: 20 }];
+		expect(calculateTotal(items)).toBe(30);
+	});
+});
+```
+
+## Readability Examples
+
+Avoid `try`/`catch` for expected failures.
+
+Bad:
+
+```typescript
+it('rejects invalid config', async () => {
+	try {
+		await loadConfig('bad.json');
+		expect.fail('expected loadConfig to throw');
+	} catch (error) {
+		expect(error).toBeInstanceOf(Error);
+	}
+});
+```
+
+Good:
+
+```typescript
+it('rejects invalid config', async () => {
+	await expect(loadConfig('bad.json')).rejects.toThrow(Error);
+});
+```
+
+Avoid `if` branches inside test bodies. Split behaviors or use `it.each`.
+
+Bad:
+
+```typescript
+it('formats output', () => {
+	const output = formatReport(mode);
+
+	if (mode === 'json') {
+		expect(JSON.parse(output)).toEqual(expected);
+	} else {
+		expect(output).toContain('Total');
+	}
+});
+```
+
+Good:
+
+```typescript
+it('formats JSON output', () => {
+	const output = formatReport('json');
+
+	expect(JSON.parse(output)).toEqual(expected);
+});
+
+it('formats table output', () => {
+	const output = formatReport('table');
+
+	expect(output).toContain('Total');
+});
+```
+
+Use `it.each` only when cases share one behavior.
+
+Good:
+
+```typescript
+it.each([
+	['daily', '2026-05-16'],
+	['monthly', '2026-05'],
+])('groups %s rows by period', (reportType, expectedPeriod) => {
+	const rows = groupUsage(reportType, usage);
+
+	expect(rows[0]?.period).toBe(expectedPeriod);
+});
+```
+
+Avoid wrapper/helper functions that hide the behavior and assertions.
+
+Bad:
+
+```typescript
+function expectReport(input: UsageEntry[], expected: ReportRow[]) {
+	expect(renderDaily(input)).toEqual(expected);
+}
+
+it('renders daily totals', () => {
+	expectReport(
+		[{ timestamp: '2026-05-16T10:00:00Z', inputTokens: 100 }],
+		[{ date: '2026-05-16', inputTokens: 100 }],
+	);
+});
+```
+
+Good:
+
+```typescript
+it('renders daily totals', () => {
+	const input = [{ timestamp: '2026-05-16T10:00:00Z', inputTokens: 100 }];
+
+	expect(renderDaily(input)).toEqual([{ date: '2026-05-16', inputTokens: 100 }]);
+});
+```
+
+Helpers are fine when they create noisy data or fixtures. Keep the assertion in the test unless the helper's name is more explicit than the assertion it hides.
+
+Use `assert` to make test preconditions explicit and to narrow nullable values. Do not use non-null assertions (`!`) to silence TypeScript when the test can fail with a useful message.
+
+Bad:
+
+```typescript
+it('returns the first row', () => {
+	const rows = getRows();
+
+	expect(rows[0]!.id).toBe('row-1');
+});
+```
+
+Good:
+
+```typescript
+it('returns the first row', () => {
+	const rows = getRows();
+	const firstRow = rows[0];
+	assert.isDefined(firstRow, 'expected at least one row');
+
+	expect(firstRow.id).toBe('row-1');
+});
+```
+
+Good for exported values that may be tree-shaken or conditionally defined:
+
+```typescript
+assert.isDefined(backendTrpcFetch, 'backendTrpcFetch should be defined');
+const backendFetch = backendTrpcFetch;
+```


### PR DESCRIPTION
## Summary
- ccusage の SKILL.md を `claude/skills/tdd/` に流用配置 (SKILL.md + references/vitest-examples.md)
- `~/.claude/skills/tdd/` への symlink は skill ディレクトリ単位 (CLAUDE.md にも追記)
- 言語非依存 (TOML 内の `!` シェル注入で Node / Python / Rust / Go を自動検出)

## Test plan
- [x] `~/.claude/skills/tdd/SKILL.md` が symlink 経由で読める
- [x] `~/.claude/skills/tdd/references/vitest-examples.md` も読める
- [ ] 新セッションで `/tdd` が skill 一覧に出ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)